### PR TITLE
Consume be weather api

### DIFF
--- a/app/facades/weather_facade.rb
+++ b/app/facades/weather_facade.rb
@@ -1,0 +1,8 @@
+class WeatherFacade
+  def self.get_forecast(zip_code)
+    forecast_data = WeatherService.get_weather(zip_code)
+    forecast = forecast_data[:data].map do |weather|
+      Forecast.new(weather)
+    end
+  end
+end

--- a/app/poros/forecast.rb
+++ b/app/poros/forecast.rb
@@ -1,0 +1,12 @@
+class Forecast
+  def initialize(data)
+    @date = data[:attributes][:date]
+    @sunrise = data[:attributes][:sunrise]
+    @sunset = data[:attributes][:sunset]
+    @high = data[:attributes][:high]
+    @low = data[:attributes][:low]
+    @humidity = data[:attributes][:humidity]
+    @wind = data[:attributes][:wind]
+    @weather = data[:attributes][:weather]
+  end
+end

--- a/app/services/weather_service.rb
+++ b/app/services/weather_service.rb
@@ -1,0 +1,10 @@
+class WeatherService
+  def self.get_weather(zip_code)
+    conn = Faraday.new("https://stormy-chamber-46446.herokuapp.com/")
+    response = conn.post("/api/v1/forecast") do |req|
+      req.body = { location: zip_code }
+    end
+
+    result = JSON.parse(response.body, symbolize_names: true)
+  end
+end

--- a/spec/facades/weather_facade_spec.rb
+++ b/spec/facades/weather_facade_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+RSpec.describe WeatherFacade do
+  describe '::get_forecast' do
+    it 'returns the forecast data for the location' do
+      zip_code = 80122
+      data = WeatherFacade.get_forecast(80112)
+      expect(data).to be_an Array
+      data.each do |forecast|
+        expect(forecast).to be_a Forecast
+      end
+    end
+  end
+end

--- a/spec/services/weather_service_spec.rb
+++ b/spec/services/weather_service_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+RSpec.describe WeatherService do
+  describe '::get_weather' do
+    it 'retrieves the weather data based on the users zip code' do
+      zip_code = 80111
+      data = WeatherService.get_weather(zip_code)
+
+      expect(data).to be_a Hash
+      expect(data[:data]).to be_an Array
+      expect(data[:data][0][:attributes]).to be_a Hash
+    end
+  end
+end


### PR DESCRIPTION
This PR:

- Consumes the main backend weather endpoint for retrieving the weather forecast based on a location.
-  [x] 100% RSpec coverage.