### PR TITLE
Modify user create flow

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -1,5 +1,5 @@
 class DashboardController < ApplicationController
   def index
-    require 'pry'; binding.pry
+
   end
 end

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -1,5 +1,5 @@
 class DashboardController < ApplicationController
   def index
-    
+    require 'pry'; binding.pry
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -6,7 +6,7 @@ class UsersController < ApplicationController
   def create
     user = UsersFacade.create_new_user(user_params.to_h)
     session[:user_id] = user.id
-    redirect_to "/plantcoach"
+    redirect_to "/dashboard"
   end
 
   private

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,10 +2,5 @@ Rails.application.routes.draw do
   root 'welcome#index'
   resources :users, only: [:new, :create]
   resources :plantcoach, only: [:index]
-  # constraints subdomain: 'plantcoach' do
-  #   get '/dashboard', to: 'dashboard#index' #, constraints: {subdomain: 'plantcoach'}
-  # end
-  # constraints subdomain: 'shop' do
-  #   get '/dashboard', to: 'dashboard#index'
-  # end
+  resources :dashboard, only: [:index]
 end

--- a/spec/features/users/new_spec.rb
+++ b/spec/features/users/new_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe 'New Users Form' do
       fill_in :password_confirmation, with: "12345"
       click_button "Create Account"
 
-      expect(current_path).to eq("/plantcoach")
+      expect(current_path).to eq("/dashboard")
     end
   end
 end


### PR DESCRIPTION
This PR:

- Is a quick modification of the direction of the flow when a user creates a new account.
- USer will now land on a dashboard page where they can decide if they want to shop or go to the plant coach.
- [x] 100% RSpec coverage.