### PR TITLE
Add session to user create

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -5,8 +5,16 @@ class UsersController < ApplicationController
 
   def create
     user = UsersFacade.create_new_user(user_params.to_h)
-    session[:user_id] = user.id
-    redirect_to "/dashboard"
+    
+    if user[:user]
+      session[:user_id] = user[:user][:data][:id]
+      session[:auth] = user[:jwt]
+      flash[:message] = "Your account has been created!  Welcome to Grants Plants, home of Plant Coach!"
+      redirect_to "/dashboard"
+    elsif user[:error]
+      flash[:message] = user[:error]
+      redirect_to "/users/new"
+    end
   end
 
   private

--- a/app/facades/users_facade.rb
+++ b/app/facades/users_facade.rb
@@ -2,6 +2,6 @@ class UsersFacade
   def self.create_new_user(user_data)
     result = UsersService.create_new_user(user_data)
     # There needs to be some error handling in case the email address is no good.
-    user_poro = User.new(result[:data][:attributes])
+    # user_poro = User.new(result[:data][:attributes])
   end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,6 +10,9 @@
   </head>
 
   <body>
+    <% flash.each do |name, msg| %>
+      <%= msg %>
+    <% end %>
     <%= yield %>
   </body>
 </html>

--- a/spec/facades/users_facade_spec.rb
+++ b/spec/facades/users_facade_spec.rb
@@ -26,10 +26,18 @@ RSpec.describe UsersFacade do
 
       user_result = UsersFacade.create_new_user(user)
 
-      expect(user_result).to be_a User
-      expect(user_result.id).to be_an Integer
-      expect(user_result.name).to be_a String
-      expect(user_result.email).to be_a String
+      expect(user_result).to be_a Hash
+      expect(user_result).to have_key(:user)
+
+      expect(user_result[:user]).to be_a Hash
+      expect(user_result[:user]).to have_key(:data)
+
+      expect(user_result[:user][:data]).to be_a Hash
+      expect(user_result[:user][:data]).to have_key(:attributes)
+      expect(user_result[:user][:data]).to have_key(:id)
+      expect(user_result[:user][:data]).to have_key(:type)
+
+      expect(user_result[:user][:data][:attributes]).to be_a Hash
     end
   end
 end

--- a/spec/features/users/new_spec.rb
+++ b/spec/features/users/new_spec.rb
@@ -29,5 +29,20 @@ RSpec.describe 'New Users Form' do
 
       expect(current_path).to eq("/dashboard")
     end
+
+    it 'will return an error if I fill out the creation form incorrectly' do
+      visit "/users/new"
+
+      fill_in :name, with: "Joel"
+      fill_in :email, with: "test@email.com"
+      fill_in :zip_code, with: "80000"
+      fill_in :password, with: "BAD PASSWORD"
+      fill_in :password_confirmation, with: "12345"
+      click_button "Create Account"
+
+      expect(current_path).to eq("/users/new")
+
+      expect(page).to have_content("Your passwords must match!")
+    end
   end
 end

--- a/spec/fixtures/create_user.json
+++ b/spec/fixtures/create_user.json
@@ -1,4 +1,5 @@
 {
+  "user": {
     "data": {
         "id": "5",
         "type": "user",
@@ -9,4 +10,6 @@
             "zip_code": "90210"
         }
     }
+  },
+  "jwt": "eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoyM30.8OunVrq2dMUSn3ZFidmGFEoDOpTTfiHO7SzmP5uy89M"
 }

--- a/spec/services/users_service_spec.rb
+++ b/spec/services/users_service_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe UsersService do
         password_confirmation: '12345'
       }
       response = File.read("spec/fixtures/create_user.json")
-  
+      # WebMock.allow_net_connect!
       stub_request(:post, "https://stormy-chamber-46446.herokuapp.com/api/v1/users").
          with(
            body: {"email"=>"joel123456@test.com", "name"=>"Joel Grant", "password"=>"12345", "password_confirmation"=>"12345", "zip_code"=>"80000"},
@@ -22,18 +22,20 @@ RSpec.describe UsersService do
        	  'User-Agent'=>'Faraday v2.2.0'
            }).
          to_return(status: 200, body: response, headers: {})
-
       new_user = UsersService.create_new_user(user)
-
+      # require 'pry'; binding.pry
       expect(new_user).to be_a Hash
-      expect(new_user[:data]).to be_a Hash
-      expect(new_user[:data]).to have_key(:id)
-      expect(new_user[:data]).to have_key(:type)
-      expect(new_user[:data]).to have_key(:attributes)
-      expect(new_user[:data][:attributes]).to have_key(:id)
-      expect(new_user[:data][:attributes]).to have_key(:name)
-      expect(new_user[:data][:attributes]).to have_key(:email)
-      expect(new_user[:data][:attributes]).to have_key(:zip_code)
+      expect(new_user[:user]).to be_a Hash
+      expect(new_user[:user]).to have_key(:data)
+
+      expect(new_user[:user][:data]).to be_a Hash
+      expect(new_user[:user][:data]).to have_key(:id)
+      expect(new_user[:user][:data]).to have_key(:type)
+      expect(new_user[:user][:data]).to have_key(:attributes)
+      expect(new_user[:user][:data][:attributes]).to have_key(:id)
+      expect(new_user[:user][:data][:attributes]).to have_key(:name)
+      expect(new_user[:user][:data][:attributes]).to have_key(:email)
+      expect(new_user[:user][:data][:attributes]).to have_key(:zip_code)
     end
   end
 end

--- a/spec/services/users_service_spec.rb
+++ b/spec/services/users_service_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe UsersService do
         password_confirmation: '12345'
       }
       response = File.read("spec/fixtures/create_user.json")
-      # WebMock.allow_net_connect!
+
       stub_request(:post, "https://stormy-chamber-46446.herokuapp.com/api/v1/users").
          with(
            body: {"email"=>"joel123456@test.com", "name"=>"Joel Grant", "password"=>"12345", "password_confirmation"=>"12345", "zip_code"=>"80000"},
@@ -23,7 +23,7 @@ RSpec.describe UsersService do
            }).
          to_return(status: 200, body: response, headers: {})
       new_user = UsersService.create_new_user(user)
-      # require 'pry'; binding.pry
+      
       expect(new_user).to be_a Hash
       expect(new_user[:user]).to be_a Hash
       expect(new_user[:user]).to have_key(:data)


### PR DESCRIPTION
## User Experience Changes: 
- User will receive feedback when successfully created an account, and will be forwarded to an authenticated dashboard session.
- User will receive feedback when passwords don't match, an erroneous email is used, or the form is incomplete and will stay on the user create page to correct the form.

## Code Changes: 
- The user creation will keep the user authenticated and direct them to a dashboard rather than making them log in immediately.  
- Flash messages are used to provide feedback.
- Testing and sad path testing added.

- [x] 100% RSpec Coverage