### PR TITLE
Redirect debug

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -1,6 +1,5 @@
 class DashboardController < ApplicationController
   def index
-    session[:user_id]
-    session[:auth]
+    
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -5,12 +5,11 @@ class UsersController < ApplicationController
 
   def create
     user = UsersFacade.create_new_user(user_params.to_h)
-    
     if user[:user]
       session[:user_id] = user[:user][:data][:id]
       session[:auth] = user[:jwt]
       flash[:message] = "Your account has been created!  Welcome to Grants Plants, home of Plant Coach!"
-      redirect_to "/dashboard"
+      redirect_to '/dashboard'
     elsif user[:error]
       flash[:message] = user[:error]
       redirect_to "/users/new"

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -1,1 +1,1 @@
-something
+<p>SOMETHING</p>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,4 +1,4 @@
-<%= form_with url: '/users', method: :post do |form| %>
+<%= form_with url: '/users', method: :post, local: true do |form| %>
   <%= form.label :name %>
   <%= form.text_field :name %>
 

--- a/spec/features/users/new_spec.rb
+++ b/spec/features/users/new_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe 'New Users Form' do
 
     it 'will return an error if I fill out the creation form incorrectly' do
       visit "/users/new"
-
+      WebMock.allow_net_connect!
       fill_in :name, with: "Joel"
       fill_in :email, with: "test@email.com"
       fill_in :zip_code, with: "80000"


### PR DESCRIPTION
## Change to User Experience:
- Redirects were not happening after creating an account.  Now a new user is redirected to their user dashboard.

## Change to Code:
- The form helper was missing the code `local: true` in the form helper to create a new user and this prevented the subsequent `redirect_to` from happening.  Instead, the user was being created but the page was staying the same.

- [x] 100% RSpec coverage