### PR TITLE
Dashboard plant data

### DIFF
--- a/app/services/plant_service.rb
+++ b/app/services/plant_service.rb
@@ -7,4 +7,14 @@ class PlantService
     response = conn.get("/api/v1/user_plants")
     JSON.parse(response.body, symbolize_names: true)
   end
+
+  def self.create_plants(plant_details, jwt)
+    conn = Faraday.new(
+      url: "https://stormy-chamber-46446.herokuapp.com",
+      params: plant_details,
+      headers: { Authorization: "Bearer #{jwt}" }
+    )
+    response = conn.post("/api/v1/plants")
+    JSON.parse(response.body, symbolize_names: true)
+  end
 end

--- a/app/services/plant_service.rb
+++ b/app/services/plant_service.rb
@@ -1,0 +1,10 @@
+class PlantService
+  def self.get_a_users_plants(jwt)
+    conn = Faraday.new(
+      url: "https://stormy-chamber-46446.herokuapp.com",
+      headers: { Authorization: "Bearer: #{jwt}" }
+    )
+    response = conn.get("/api/v1/user_plants")
+    JSON.parse(response.body, symbolize_names: true)
+  end
+end

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -1,3 +1,6 @@
 <%= @user['name'] %>'s Dashboard
 Name: <%= @user['name'] %>
 Email: <%= @user['email'] %>
+
+
+<p><%= @user['name'] %>'s Plants</p>

--- a/spec/features/dashboard/index_spec.rb
+++ b/spec/features/dashboard/index_spec.rb
@@ -22,10 +22,26 @@ RSpec.describe 'User Dashboard' do
       click_button "Log In"
 
       expect(current_path).to eq('/dashboard')
-      
+
       expect(page).to have_content("Joel Grant's Dashboard")
       expect(page).to have_content("Name: Joel Grant")
       expect(page).to have_content("Email: joel@plantcoach.com")
+    end
+
+    it 'shows the plants in the users garden' do
+      visit '/'
+      click_button "Log In"
+      expect(current_path).to eq("/login")
+
+      WebMock.allow_net_connect!
+      fill_in :email, with: "joel@plantcoach.com"
+      fill_in :password, with: "12345"
+      click_button "Log In"
+
+      expect(current_path).to eq('/dashboard')
+
+      # require 'pry'; binding.pry
+      expect(page).to have_content("Joel Grant's Plants")
     end
   end
 end

--- a/spec/services/plant_service_spec.rb
+++ b/spec/services/plant_service_spec.rb
@@ -1,0 +1,49 @@
+require 'rails_helper'
+
+RSpec.describe PlantService do
+  describe '::get_a_users_plants' do
+    it 'returns the plants that a user has selected to plant' do
+      login_params = { email: 'joel@plantcoach.com', password: '12345' }
+      login_response = SessionService.user_login(login_params)
+      data = PlantService.get_a_users_plants(login_response[:jwt])
+
+      expect(data[:data]).to be_an Array
+      # Add more tests after functionality is made.
+    end
+  end
+
+  describe '::create_plants' do
+    it 'makes a plant in the plant database for the entire application' do
+      login_params = { email: 'joel@plantcoach.com', password: '12345' }
+      login_response = SessionService.user_login(login_params)
+
+      plant_details = {
+        plant_type: "Watermelon",
+        name: "Sugar Baby",
+        days_relative_to_frost_date: 7,
+        days_to_maturity: 60,
+        hybrid_status: 1
+      }
+
+      data = PlantService.create_plants(plant_details, login_response[:jwt])
+      expect(data[:data]).to have_key(:id)
+      expect(data[:data]).to have_key(:type)
+      expect(data[:data]).to have_key(:attributes)
+
+      expect(data[:data][:attributes]).to have_key(:plant_type)
+      expect(data[:data][:attributes][:plant_type]).to be_a String
+
+      expect(data[:data][:attributes]).to have_key(:name)
+      expect(data[:data][:attributes][:name]).to be_a String
+
+      expect(data[:data][:attributes]).to have_key(:days_relative_to_frost_date)
+      expect(data[:data][:attributes][:days_relative_to_frost_date]).to be_an Integer
+
+      expect(data[:data][:attributes]).to have_key(:days_to_maturity)
+      expect(data[:data][:attributes][:days_to_maturity]).to be_an Integer
+
+      expect(data[:data][:attributes]).to have_key(:hybrid_status)
+      expect(data[:data][:attributes][:hybrid_status]).to be_an Integer
+    end
+  end
+end


### PR DESCRIPTION
## Changes to user experience:
- A header for the users plants is displayed on their dashboard.#13 

## Changes to code:
- Two methods were created in the plant service:
  - First: gets a plants that belong to a specific user.
  - Second: Posts a requests to create plants in the database from which a user can choose.

- [] 100% RSpec Coverage