### PR TITLE
Add user plant

### DIFF
--- a/app/controllers/user_plants_controller.rb
+++ b/app/controllers/user_plants_controller.rb
@@ -1,0 +1,7 @@
+class UserPlantsController < ApplicationController
+  def create
+    plant = PlantFacade.create_user_plants(params[:plant_id], session[:auth])
+    flash[:message] = "#{plant.name} #{plant.plant_type} has been added to your garden!"
+    redirect_to '/plants'
+  end
+end

--- a/app/facades/plant_facade.rb
+++ b/app/facades/plant_facade.rb
@@ -12,4 +12,9 @@ class PlantFacade
       Plant.new(plant)
     end
   end
+
+  def self.create_user_plants(plant_id, jwt)
+    plant_data = PlantService.create_user_plants(plant_id, jwt)
+    Plant.new(plant_data[:data])
+  end
 end

--- a/app/facades/plant_facade.rb
+++ b/app/facades/plant_facade.rb
@@ -5,4 +5,11 @@ class PlantFacade
       Plant.new(plant)
     end
   end
+
+  def self.all_user_plants(jwt)
+    plant_data = PlantService.get_a_users_plants(jwt)
+    plants = plant_data[:data].map do |plant|
+      Plant.new(plant)
+    end
+  end
 end

--- a/app/services/plant_service.rb
+++ b/app/services/plant_service.rb
@@ -26,4 +26,14 @@ class PlantService
     response = conn.get("/api/v1/plants")
     JSON.parse(response.body, symbolize_names: true)
   end
+
+  def self.create_user_plants(plant_id, jwt)
+    conn = Faraday.new(
+      url: "https://stormy-chamber-46446.herokuapp.com",
+      params: { plant_id: plant_id },
+      headers: { Authorization: "Bearer #{jwt}"}
+    )
+    response = conn.post("/api/v1/user_plants")
+    JSON.parse(response.body, symbolize_names: true)
+  end
 end

--- a/app/views/plants/index.html.erb
+++ b/app/views/plants/index.html.erb
@@ -1,3 +1,4 @@
+<%= button_to "Create a New Plant", "/plants/new", method: :get %>
 <%= button_to "Return to My Dashboard", "/dashboard", method: :get %>
 <% @plants.each do |plant| %>
   <%= plant.name %>

--- a/app/views/plants/index.html.erb
+++ b/app/views/plants/index.html.erb
@@ -2,4 +2,5 @@
 <%= button_to "Return to My Dashboard", "/dashboard", method: :get %>
 <% @plants.each do |plant| %>
   <%= plant.name %>
+  <%= button_to "Add #{plant.name} #{plant.plant_type} to my Garden", '/user_plants', params: { plant_id: plant.id }  %>
 <% end %>

--- a/app/views/plants/index.html.erb
+++ b/app/views/plants/index.html.erb
@@ -1,3 +1,4 @@
+<%= button_to "Return to My Dashboard", "/dashboard", method: :get %>
 <% @plants.each do |plant| %>
   <%= plant.name %>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
   resources :plantcoach, only: [:index]
   resources :dashboard, only: [:index]
   resources :plants, only: [:index, :new, :create]
+  resources :user_plants, only: [:create]
   get '/login', to: 'sessions#new'
   post '/login', to: 'sessions#create'
 end

--- a/spec/features/plants/index_spec.rb
+++ b/spec/features/plants/index_spec.rb
@@ -59,7 +59,6 @@ RSpec.describe 'Plants Index Page' do
       click_button "Create Plant"
 
       expect(current_path).to eq("/plants")
-      save_and_open_page
       # expect(page).to have_button("Add Sugar Baby Watermelon to my Garden", disabled: false)
 
       # click_button "Add Sugar Baby Watermelon to my Garden"

--- a/spec/features/plants/index_spec.rb
+++ b/spec/features/plants/index_spec.rb
@@ -1,0 +1,72 @@
+require 'rails_helper'
+
+RSpec.describe 'Plants Index Page' do
+  before(:each) do
+    visit '/'
+    click_button "Log In"
+    expect(current_path).to eq("/login")
+
+    WebMock.allow_net_connect!
+    fill_in :email, with: "joel@plantcoach.com"
+    fill_in :password, with: "12345"
+    click_button "Log In"
+
+    expect(current_path).to eq("/dashboard")
+    # visit '/plants'
+  end
+  context 'when I go to the plants index page and see the list of plants' do
+    it 'has a button by each plant to add it to my garden' do
+      visit '/plants'
+      # Based on Seed data from BE Repo
+      # save_and_open_page
+      # expect(page).to have_button("Add Jalafuego Pepper to my Garden", disabled: true)
+      # expect(page).to have_button("Add Rosa Bianca Eggplant to my Garden", disabled: true)
+      # expect(page).to have_button("Add Sungold Tomato to my Garden", disabled: true)
+      # expect(page).to have_button("Add French Breakfast Radish to my Garden", disabled: true)
+      # expect(page).to have_button("Add Provider Pole Bean to my Garden", disabled: true)
+      # expect(page).to have_button("Add Toma Verde Tomatillo to my Garden", disabled: false)
+      click_button "Add Toma Verde Tomatillo to my Garden"
+
+      expect(page).to have_content("Toma Verde Tomatillo has been added to your garden!")
+
+      # expect(page).to have_button("Add Toma Verde Tomatillo to my Garden", disabled: false)
+
+      expect(current_path).to eq("/plants")
+    end
+
+    it 'has a button to return to the user dashboard' do
+      visit '/plants'
+
+      click_button "Return to My Dashboard"
+
+      expect(current_path).to eq("/dashboard")
+
+      expect(page).to have_content("Joel Grant's Dashboard")
+    end
+
+    it 'has a button to add more plants from within the plant index' do
+      visit '/plants'
+
+      click_button "Create a New Plant"
+
+      expect(current_path).to eq("/plants/new")
+
+      fill_in :plant_type, with: 'Watermelon'
+      fill_in :name, with: 'Sugar Baby'
+      fill_in :days_relative_to_frost_date, with: 14
+      fill_in :days_to_maturity, with: 89
+      fill_in :hybrid_status, with: 1
+      click_button "Create Plant"
+
+      expect(current_path).to eq("/plants")
+      save_and_open_page
+      # expect(page).to have_button("Add Sugar Baby Watermelon to my Garden", disabled: false)
+
+      # click_button "Add Sugar Baby Watermelon to my Garden"
+      # expect(page).to have_content("Add Sugar Baby Watermelon to my Garden")
+      expect(current_path).to eq("/plants")
+
+      # expect(page).to have_button("Add Sugar Baby Watermelon to my Garden", disabled: true)
+    end
+  end
+end


### PR DESCRIPTION
## Changes to user experience: 
- When a user visits the plant index they can add any of the plants as their user plant.
- There are navigation buttons added to the plants index page for creating more plants or for returning to the dashboard.
- Upon adding a plant, they may continue clicking on others on the same site without being redirected away.

## Changes to code:
- Create process for using the endpoint to create user plants.
- Created a userplants controller and basic create action.