### PR TITLE
User plants delete feature

### DIFF
--- a/app/controllers/user_plants_controller.rb
+++ b/app/controllers/user_plants_controller.rb
@@ -4,4 +4,15 @@ class UserPlantsController < ApplicationController
     flash[:message] = "#{plant.name} #{plant.plant_type} has been added to your garden!"
     redirect_to '/plants'
   end
+
+  def destroy
+    if session[:auth] != nil
+      result = PlantFacade.destroy_user_plant(params[:id], session[:auth])
+      flash[:message] = "Plant removed!"
+      redirect_to "/dashboard"
+    else
+      flash[:message] = "Please log in!"
+      redirect_to "/"
+    end
+  end
 end

--- a/app/facades/plant_facade.rb
+++ b/app/facades/plant_facade.rb
@@ -17,4 +17,9 @@ class PlantFacade
     plant_data = PlantService.create_user_plants(plant_id, jwt)
     Plant.new(plant_data[:data])
   end
+
+  def self.destroy_user_plant(plant_id, jwt)
+    plant_data = PlantService.destroy_user_plant(plant_id, jwt)
+    
+  end
 end

--- a/app/services/plant_service.rb
+++ b/app/services/plant_service.rb
@@ -36,4 +36,13 @@ class PlantService
     response = conn.post("/api/v1/user_plants")
     JSON.parse(response.body, symbolize_names: true)
   end
+
+  def self.destroy_user_plant(plant_id, jwt)
+    conn = Faraday.new(
+      url: "https://stormy-chamber-46446.herokuapp.com",
+      headers: { Authorization: "Bearer #{jwt}" }
+    )
+    response = conn.delete("/api/v1/user_plants/#{plant_id}")
+    JSON.parse(response.body, symbolize_names: true)
+  end
 end

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -6,5 +6,7 @@ Email: <%= @user['email'] %>
 
 <p><%= @user['name'] %>'s Plants</p>
 <% @user_plants.each do |plant| %>
-  <p><%= plant.name %> <%= plant.plant_type %></p>
+  <p><%= plant.name %>
+    <%= plant.plant_type %> </p>
+  <p><%= button_to "Remove #{plant.name} #{plant.plant_type}", "/user_plants/#{plant.id}", method: :delete %></p>
 <% end %>

--- a/app/views/plants/index.html.erb
+++ b/app/views/plants/index.html.erb
@@ -1,6 +1,7 @@
 <%= button_to "Create a New Plant", "/plants/new", method: :get %>
 <%= button_to "Return to My Dashboard", "/dashboard", method: :get %>
 <% @plants.each do |plant| %>
-  <%= plant.name %>
+  <p><%= plant.name %>
+    <%= plant.plant_type %></p>
   <%= button_to "Add #{plant.name} #{plant.plant_type} to my Garden", '/user_plants', params: { plant_id: plant.id }  %>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
   resources :plantcoach, only: [:index]
   resources :dashboard, only: [:index]
   resources :plants, only: [:index, :new, :create]
-  resources :user_plants, only: [:create]
+  resources :user_plants, only: [:create, :destroy]
   get '/login', to: 'sessions#new'
   post '/login', to: 'sessions#create'
 end

--- a/spec/features/dashboard/index_spec.rb
+++ b/spec/features/dashboard/index_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'User Dashboard' do
       expect(page).to have_content("You must log in!")
     end
   end
-  
+
   context 'When I visit the dashboard as an authenticated user' do
     it 'shows me my name and email' do
       visit '/'
@@ -59,6 +59,52 @@ RSpec.describe 'User Dashboard' do
       expect(page).to have_content("Sungold Tomato")
       expect(page).to have_content("Jalafuego Pepper")
       expect(page).to have_content("Rosa Bianca Eggplant")
+    end
+
+    it 'has a button to remove the plant from the users dashboard and planner' do
+      visit '/'
+      click_button "Log In"
+      expect(current_path).to eq("/login")
+
+      WebMock.allow_net_connect!
+      fill_in :email, with: "joel@plantcoach.com"
+      fill_in :password, with: "12345"
+      click_button "Log In"
+
+      visit '/dashboard'
+
+      expect(current_path).to eq("/dashboard")
+
+      expect(page).to have_content("Sungold Tomato")
+      expect(page).to have_content("Jalafuego Pepper")
+      expect(page).to have_content("Rosa Bianca Eggplant")
+
+      click_button "Remove Sungold Tomato"
+      expect(current_path).to eq("/dashboard")
+      expect(page).to have_content("Plant removed!")
+      expect(page).to_not have_content("Sungold Tomato")
+      expect(page).to have_content("Jalafuego Pepper")
+      expect(page).to have_content("Rosa Bianca Eggplant")
+
+      click_button "Remove Jalafuego Pepper"
+      expect(current_path).to eq("/dashboard")
+      expect(page).to have_content("Plant removed!")
+      expect(page).to_not have_content("Sungold Tomato")
+      expect(page).to_not have_content("Jalafuego Pepper")
+      expect(page).to have_content("Rosa Bianca Eggplant")
+
+      click_button "Remove Rosa Bianca Eggplant"
+      expect(page).to have_content("Plant removed!")
+      expect(current_path).to eq("/dashboard")
+      expect(page).to_not have_content("Sungold Tomato")
+      expect(page).to_not have_content("Jalafuego Pepper")
+      expect(page).to_not have_content("Rosa Bianca Eggplant")
+      # This is to re-add the plants to the users dashboard for other tests to pass
+      visit '/plants'
+      click_button "Add Sungold Tomato to my Garden"
+      click_button "Add Jalafuego Pepper to my Garden"
+      click_button "Add Rosa Bianca Eggplant to my Garden"
+      click_button "Return to My Dashboard"
     end
   end
 end


### PR DESCRIPTION
## Changes to User Experience:
- When the user is on their dashboard they are able to see a button which allows them to delete the plant from their dashboard.
- The plant will still exist in the database and can be re-added. 

## Changes to Code:
- Consumes the DELETE /api/v1/user_plants endpoint from the BE repo to remove the association of a plant from a user but still keeping the plant in the database.
