### PR TITLE
Consume frost data

### DIFF
--- a/app/services/frost_date_service.rb
+++ b/app/services/frost_date_service.rb
@@ -1,0 +1,10 @@
+class FrostDateService
+  def self.get_frost_dates(jwt)
+    conn = Faraday.new(
+      url: "https://stormy-chamber-46446.herokuapp.com",
+      headers: { Authorization: "Bearer: #{jwt}" }
+    )
+    response = conn.get("/api/v1/frost_dates")
+    JSON.parse(response.body, symbolize_names: true)
+  end
+end

--- a/spec/services/frost_date_service_spec.rb
+++ b/spec/services/frost_date_service_spec.rb
@@ -7,7 +7,15 @@ RSpec.describe FrostDateService do
       login_params = { email: 'joel@plantcoach.com', password: '12345' }
       login_response = SessionService.user_login(login_params)
       frost_date_data = FrostDateService.get_frost_dates(login_response[:jwt])
-      require 'pry'; binding.pry
+
+      expect(frost_date_data).to be_a Hash
+      expect(frost_date_data[:data][:attributes]).to have_key(:id)
+      expect(frost_date_data[:data][:attributes]).to have_key(:zip_code)
+      expect(frost_date_data[:data][:attributes]).to have_key(:location_name)
+      expect(frost_date_data[:data][:attributes]).to have_key(:lat)
+      expect(frost_date_data[:data][:attributes]).to have_key(:lon)
+      expect(frost_date_data[:data][:attributes]).to have_key(:spring_frost)
+      expect(frost_date_data[:data][:attributes]).to have_key(:fall_frost)
     end
   end
 end

--- a/spec/services/frost_date_service_spec.rb
+++ b/spec/services/frost_date_service_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+RSpec.describe FrostDateService do
+  describe '::get_frost_dates' do
+    it 'returns the frost date data for the user' do
+      WebMock.allow_net_connect!
+      login_params = { email: 'joel@plantcoach.com', password: '12345' }
+      login_response = SessionService.user_login(login_params)
+      frost_date_data = FrostDateService.get_frost_dates(login_response[:jwt])
+      require 'pry'; binding.pry
+    end
+  end
+end


### PR DESCRIPTION
## Changes to User Experience
- NA

## Changes to code
- This consumes the frost date endpoint from plant_coach to get an idea of a users approximate growing season which will later dictate the recommendations for creating a planting schedule.