### PR TITLE
Add frost to dashboard

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -4,6 +4,7 @@ class DashboardController < ApplicationController
       @user = session[:user_data]
       @user_plants = PlantFacade.all_user_plants(session[:auth])
       @weekly_forecast = WeatherFacade.get_forecast(session[:auth])
+      @frost_data = FrostDateFacade.get_frost_dates(session[:auth])
       # Get basic user information
       # Get a user's plant information
       # Get a user's frost date information

--- a/app/facades/frost_date_facade.rb
+++ b/app/facades/frost_date_facade.rb
@@ -1,0 +1,6 @@
+class FrostDateFacade
+  def self.get_frost_dates(jwt)
+    frost_data = FrostDateService.get_frost_dates(jwt)
+    result = FrostDates.new(frost_data)
+  end
+end

--- a/app/poros/frost_dates.rb
+++ b/app/poros/frost_dates.rb
@@ -1,0 +1,11 @@
+class FrostDates
+  attr_reader :zip_code, :location_name, :lat, :lon, :spring_frost, :fall_frost
+  def initialize(data)
+    @zip_code = data[:data][:attributes][:zip_code]
+    @location_name = data[:data][:attributes][:location_name]
+    @lat = data[:data][:attributes][:lat]
+    @lon = data[:data][:attributes][:lon]
+    @spring_frost = data[:data][:attributes][:spring_frost].to_date
+    @fall_frost = data[:data][:attributes][:fall_frost].to_date
+  end
+end

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -3,6 +3,13 @@
 Name: <%= @user['name'] %>
 Email: <%= @user['email'] %>
 
+<div id="frost-information">
+  <h2>My Frost Information</h2>
+  <p>Approximate Last Frost (Spring): <%= @frost_data.spring_frost %></p>
+  <p>Approximate First Frost (Fall): <%= @frost_data.fall_frost %></p>
+  <p>Approximate length of frost-free growing:</p>
+  <p>My Location: <%= @frost_data.location_name %> </p>
+</div>
 
 <p><%= @user['name'] %>'s Plants</p>
 <% @user_plants.each do |plant| %>

--- a/spec/features/dashboard/index_spec.rb
+++ b/spec/features/dashboard/index_spec.rb
@@ -137,5 +137,26 @@ RSpec.describe 'User Dashboard' do
       click_button "Plants Index Page"
       expect(current_path).to eq("/plants")
     end
+
+    it 'has a section for displaying a users frost date information' do
+      visit '/'
+      click_button "Log In"
+      expect(current_path).to eq("/login")
+
+      WebMock.allow_net_connect!
+      fill_in :email, with: "joel@plantcoach.com"
+      fill_in :password, with: "12345"
+      click_button "Log In"
+
+      expect(current_path).to eq("/dashboard")
+
+      within "#frost-information" do
+        expect(page).to have_content("My Frost Information")
+        expect(page).to have_content("Approximate Last Frost (Spring): ")
+        expect(page).to have_content("Approximate First Frost (Fall): ")
+        expect(page).to have_content("Approximate length of frost-free growing:")
+        expect(page).to have_content("My Location: Greenwood Village")
+      end
+    end
   end
 end


### PR DESCRIPTION
## Changes to User Experience
- Frost date information is now available on the user dashboard.

## Changes to Code
- Uses the data from the consumed frost date endpoint to display this information on the user dashboard.
- Added new service, facade, poro, rspec tests and dashboard controller variable.